### PR TITLE
Content attachment

### DIFF
--- a/data/schema.json
+++ b/data/schema.json
@@ -485,20 +485,13 @@
           "title": "Image"
         },
         "filename": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "title": "Filename"
+          "default": "",
+          "title": "Filename",
+          "type": "string"
         }
       },
       "required": [
-        "image",
-        "filename"
+        "image"
       ],
       "title": "ContentBlockContentAttachment",
       "type": "object"

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -25,7 +25,7 @@ export type Text =
     };
 export type ContentTextMarkup = "none" | "html" | "markdown";
 export type Image = string | null;
-export type Filename = string | null;
+export type Filename = string;
 export type Attachments = ContentBlockContentAttachment[];
 export type Contents = Content[];
 export type NextBlockId3 = string | null;
@@ -326,7 +326,7 @@ export interface ContentText {
 }
 export interface ContentBlockContentAttachment {
   image: Image;
-  filename: Filename;
+  filename?: Filename;
   [k: string]: unknown;
 }
 /**

--- a/frontend/src/studio/nodes/ContentBlock/Modal.svelte
+++ b/frontend/src/studio/nodes/ContentBlock/Modal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import type { Attachments, ContentBlock, ContentBlockContentAttachment, Image } from "../../../api/types";
+  import { Fileupload, Helper, Label, Listgroup, ListgroupItem } from "flowbite-svelte";
+  import type { Attachments, ContentBlock, ContentBlockContentAttachment } from "../../../api/types";
   import LocalizableTextInput from "../../components/LocalizableTextInput.svelte";
-  import { Fileupload, Label, Helper, Listgroup, ListgroupItem } from "flowbite-svelte";
   import NodeModalBody from "../../components/NodeModalBody.svelte";
   import NodeModalControls from "../../components/NodeModalControls.svelte";
   import { NODE_TITLE } from "../display";
@@ -55,7 +55,7 @@
     return file;
   }
 
-  function initFiles(attachments: Array<any>): FileList | undefined {
+  function initFiles(attachments: Array<ContentBlockContentAttachment>): FileList | undefined {
     if (!attachments.length) return undefined;
 
     // NOTE DataTransfer is a hack, used to create a File List, which is required for a UI component

--- a/telebot_constructor/user_flow/blocks/content.py
+++ b/telebot_constructor/user_flow/blocks/content.py
@@ -48,7 +48,7 @@ class ContentText(BaseModel):
 
 class ContentBlockContentAttachment(ExactlyOneNonNullFieldModel):
     image: Optional[str]  # base64-encoded
-    filename: Optional[str]
+    filename: str = ""
 
     def content(self) -> str:
         # runtime guarantee that at least one (now it's always image) option is non-None


### PR DESCRIPTION
Closes #30 

Для компонента контент выполнена форма для добавления файлов. Пользователь выбирает файлы, при сохранении они кобируются в base64 и записываются в конфиг.
При открытии компонента, если в него уже были добавлены вложения, они перекодируются в обратно в файлы. Их нельзя поменять, но они видны в списке, любой другой пользовательский выбор их перезапишет, если результат действий будет сохранен.


https://github.com/bots-against-war/telebot-constructor/assets/90175094/6f540e5a-4c7c-420a-ac23-758cc3576d37

> [!WARNING]
> Форма позволяет крепить какие-угодно файлы в каком угодно колличестве, клиентской валидации в этой реализации нет совсем.